### PR TITLE
Add Django Docs Clone - A Beginner-Friendly Web-Doc

### DIFF
--- a/Django-Doc_app/.gitignore
+++ b/Django-Doc_app/.gitignore
@@ -1,0 +1,72 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.mypy_cache/
+
+# Django stuff:
+*.log
+local_settings.py
+media
+staticfiles
+
+# SQLite database (unused by this project, but ignore anyway)
+db.sqlite3
+
+# Environments
+.venv/
+venv/
+env/
+ENV/
+
+# IDE/editor
+.vscode/
+.idea/
+*.iml
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/Django-Doc_app/LICENSE
+++ b/Django-Doc_app/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 The django_google_doc_clone Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Django-Doc_app/README.md
+++ b/Django-Doc_app/README.md
@@ -1,0 +1,90 @@
+# Simple Docs Clone — Django Beginner Project
+
+A beginner-friendly Django project that serves a single-page, offline-capable text editor similar to Google Docs. The editor is powered by Quill.js and saves everything to your browser's localStorage. No database is used for documents.
+
+## Features
+- Rich-text editor (bold, italic, underline, strikethrough, headings, size, color, lists, blockquote, code, links, images, undo/redo)
+- Editable document title
+- Autosave to localStorage every 5 seconds and on blur/unload
+- File operations: New, Import (HTML/JSON), Save HTML, Export Markdown, Export PDF, Clear Local Data
+- Live word and character count
+- Responsive, clean UI similar to Google Docs
+- Light/Dark theme with persistence
+- Optional version snapshots (keeps 3 previous saves) with restore
+
+## Tech Stack
+- Python 3.11
+- Django 4.2
+- SQLite (default, unused)
+- HTML5, CSS3, JavaScript (ES6)
+- Frontend via CDN: Quill.js, Turndown.js, html2pdf.js, FontAwesome, Google Fonts (Inter)
+
+## Project Structure
+```
+django_google_doc_clone/
+├─ manage.py
+├─ requirements.txt
+├─ README.md
+├─ LICENSE
+├─ django_google_doc_clone/
+│  ├─ __init__.py
+│  ├─ settings.py
+│  ├─ urls.py
+│  ├─ wsgi.py
+│  └─ asgi.py
+└─ editor/
+   ├─ __init__.py
+   ├─ views.py
+   ├─ urls.py
+   ├─ templates/
+   │  └─ editor/
+   │     └─ index.html
+   └─ static/
+      └─ editor/
+         ├─ css/
+         │  └─ styles.css
+         ├─ js/
+         │  └─ app.js
+         └─ favicon.svg
+```
+
+## Setup
+
+Linux/macOS (bash):
+```
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python manage.py runserver
+```
+
+Windows (PowerShell):
+```
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+python manage.py runserver
+```
+
+Open the app at: http://127.0.0.1:8000/
+
+## Using the Editor
+- Title: Click the title at the top to edit.
+- Toolbar: Use the toolbar for formatting (bold, italic, etc.).
+- Autosave: Content and title autosave every 5 seconds and on leaving the page.
+- New: Clears the current document (keeps theme and snapshots).
+- Import: Load an HTML or JSON file. JSON can be a raw Quill Delta or an object with `{ delta, title }`.
+- Save HTML: Downloads a self-contained HTML file with embedded styles.
+- Export Markdown: Converts the current document to .md using Turndown.
+- Export PDF: Creates a PDF via html2pdf.js.
+- Clear Local Data: Removes saved content, title, and snapshots from localStorage.
+- Versions: Keeps the last 3 autosave snapshots. Select one and Restore.
+
+## Deployment
+- Render or PythonAnywhere: Deploy this Django app as usual. Since all logic is client-side, no DB setup is required beyond Django defaults.
+- GitHub Pages: The editor is a static page at `editor/templates/editor/index.html` using static assets at `editor/static/editor/`. You can host it as a pure static site by copying `index.html` and the `static/editor` folder to a static hosting location and replacing `{% load static %}` and `{% static ... %}` with plain relative paths.
+
+## Contributing
+Contributions are welcome! Please fork the repo, create a feature branch, and open a pull request. Beginner-friendly issues are encouraged for Hacktoberfest.
+
+## License
+MIT License — see LICENSE for details.

--- a/Django-Doc_app/django_google_doc_clone/asgi.py
+++ b/Django-Doc_app/django_google_doc_clone/asgi.py
@@ -1,0 +1,8 @@
+"""ASGI config for django_google_doc_clone project."""
+
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_google_doc_clone.settings")
+
+application = get_asgi_application()

--- a/Django-Doc_app/django_google_doc_clone/settings.py
+++ b/Django-Doc_app/django_google_doc_clone/settings.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+# Base directory
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = "django-insecure-change-me"
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
+
+# Application definition
+INSTALLED_APPS = [
+    "django.contrib.staticfiles",
+    "editor",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "django_google_doc_clone.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "django_google_doc_clone" / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.template.context_processors.static",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "django_google_doc_clone.wsgi.application"
+ASGI_APPLICATION = "django_google_doc_clone.asgi.application"
+
+# Database (unused by this project beyond Django defaults)
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+# Internationalization
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+# Static files (CSS, JavaScript, Images)
+STATIC_URL = "/static/"
+
+# Default primary key field type
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/Django-Doc_app/django_google_doc_clone/templates/404.html
+++ b/Django-Doc_app/django_google_doc_clone/templates/404.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Page not found · Simple Docs</title>
+    <style>
+      :root { --bg: #0b1320; --card:#111827; --text:#e5e7eb; --muted:#9ca3af; --accent:#3b82f6; }
+      html, body { height: 100%; }
+      body { margin:0; display:grid; place-items:center; background:var(--bg); color:var(--text); font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif; }
+      .card { background: var(--card); padding: 2rem 2.5rem; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.4); text-align:center; }
+      a { color: var(--accent); text-decoration: none; font-weight: 600; }
+      h1 { margin: 0 0 .5rem; font-size: 1.6rem; }
+      p { margin: 0 0 1.25rem; color: var(--muted); }
+      .btn { display:inline-block; background: var(--accent); color:white; padding:.6rem 1.1rem; border-radius:8px; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>404 · Page not found</h1>
+      <p>The page you requested does not exist.</p>
+      <a class="btn" href="/editor/">Go to the Editor</a>
+    </div>
+  </body>
+</html>

--- a/Django-Doc_app/django_google_doc_clone/urls.py
+++ b/Django-Doc_app/django_google_doc_clone/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path, include
+from django.views.generic import RedirectView
+
+urlpatterns = [
+    path("", RedirectView.as_view(url="/editor/", permanent=False), name="root-redirect"),
+    path("editor/", include("editor.urls")),
+]

--- a/Django-Doc_app/django_google_doc_clone/wsgi.py
+++ b/Django-Doc_app/django_google_doc_clone/wsgi.py
@@ -1,0 +1,8 @@
+"""WSGI config for django_google_doc_clone project."""
+
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_google_doc_clone.settings")
+
+application = get_wsgi_application()

--- a/Django-Doc_app/editor/static/editor/css/styles.css
+++ b/Django-Doc_app/editor/static/editor/css/styles.css
@@ -1,0 +1,147 @@
+/* Root theme variables */
+:root {
+  --bg: #f5f7fb;
+  --card: #ffffff;
+  --text: #0f172a;
+  --muted: #64748b;
+  --border: #e2e8f0;
+  --shadow: 0 10px 30px rgba(24, 39, 75, 0.12);
+  --accent: #3b82f6;
+}
+
+html[data-theme="dark"], body[data-theme="dark"] {
+  --bg: #0b1320;
+  --card: #111827;
+  --text: #e5e7eb;
+  --muted: #94a3b8;
+  --border: #1f2937;
+  --shadow: 0 10px 30px rgba(0,0,0,0.6);
+  --accent: #60a5fa;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+}
+
+/* App bar */
+.appbar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: .6rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+.appbar__brand { font-weight: 800; letter-spacing: .2px; }
+.appbar__logo { color: var(--accent); margin-right: .5rem; }
+.icon-btn {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  padding: .45rem .6rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.icon-btn:hover { background: rgba(0,0,0,0.04); }
+
+/* Container */
+.container {
+  max-width: 1080px;
+  margin: 1rem auto 3rem;
+  padding: 0 1rem;
+}
+
+/* Title row and actions */
+.title-row { display: flex; align-items: center; gap: .75rem; flex-wrap: wrap; }
+.title-input {
+  flex: 1 1 320px;
+  font-size: 1.25rem;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text);
+  padding: .5rem .75rem;
+  border-radius: 10px;
+}
+.title-input::placeholder { color: var(--muted); }
+
+.actions { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; }
+.btn {
+  display: inline-flex; align-items: center; gap: .4rem;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text);
+  padding: .45rem .7rem;
+  border-radius: 10px;
+  cursor: pointer;
+}
+.btn:hover { box-shadow: var(--shadow); }
+.btn-danger { border-color: #ef4444; color: #ef4444; }
+.btn-secondary { border-color: var(--muted); color: var(--muted); }
+
+/* Versions label */
+.versions { display: inline-flex; align-items: center; gap: .4rem; }
+.versions select { padding: .4rem; border-radius: 8px; border: 1px solid var(--border); background: var(--card); color: var(--text); }
+
+/* Toolbar */
+.toolbar {
+  position: sticky; top: 58px; z-index: 900; /* below appbar */
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  margin: 1rem 0;
+}
+.toolbar .ql-formats button#btn-undo,
+.toolbar .ql-formats button#btn-redo {
+  width: 32px; height: 28px; display: inline-grid; place-items: center;
+  border: 0; background: transparent; color: var(--text);
+}
+
+/* Page */
+.page {
+  max-width: 816px; /* ~8.5in */
+  margin: 1rem auto;
+  border-radius: 14px;
+  background: var(--card);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+.editor {
+  min-height: 900px;
+  padding: 2.2rem;
+}
+
+/* Status bar */
+.status-bar {
+  margin-top: 1rem;
+  display: flex; align-items: center; justify-content: space-between;
+  color: var(--muted);
+}
+.save-indicator { font-variant-numeric: tabular-nums; }
+
+/* Quill theme tweaks */
+.ql-toolbar.ql-snow { border: none; border-bottom: 1px solid var(--border); border-radius: 12px 12px 0 0; }
+.ql-container.ql-snow { border: none; }
+.ql-editor { font-size: 16px; line-height: 1.65; }
+.ql-editor h1 { font-size: 2em; }
+.ql-editor h2 { font-size: 1.6em; }
+.ql-editor h3 { font-size: 1.35em; }
+
+/* Dark mode fixes for Quill */
+html[data-theme="dark"] .ql-toolbar .ql-stroke { stroke: var(--text); }
+html[data-theme="dark"] .ql-toolbar .ql-fill { fill: var(--text); }
+html[data-theme="dark"] .ql-picker { color: var(--text); }
+
+/* Responsive */
+@media (max-width: 720px) {
+  .editor { padding: 1rem; }
+  .toolbar { top: 52px; }
+}

--- a/Django-Doc_app/editor/static/editor/favicon.svg
+++ b/Django-Doc_app/editor/static/editor/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+  </defs>
+  <rect rx="10" ry="10" x="4" y="4" width="56" height="56" fill="url(#g)"/>
+  <rect x="14" y="16" width="36" height="32" rx="4" ry="4" fill="#fff"/>
+  <rect x="18" y="22" width="28" height="4" rx="2" ry="2" fill="#dbeafe"/>
+  <rect x="18" y="30" width="22" height="4" rx="2" ry="2" fill="#bfdbfe"/>
+  <rect x="18" y="38" width="18" height="4" rx="2" ry="2" fill="#bfdbfe"/>
+</svg>

--- a/Django-Doc_app/editor/static/editor/js/app.js
+++ b/Django-Doc_app/editor/static/editor/js/app.js
@@ -1,0 +1,305 @@
+// Simple Google Docs Clone front-end logic
+// All document data is kept in the browser via localStorage.
+
+(function () {
+  const STORAGE = {
+    title: 'ggdoc:title',
+    delta: 'ggdoc:delta',
+    html: 'ggdoc:html',
+    theme: 'ggdoc:theme',
+    snapshots: 'ggdoc:snapshots'
+  };
+
+  const $ = (sel) => document.querySelector(sel);
+  const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+
+  const titleEl = $('#doc-title');
+  const fileInput = $('#file-input');
+  const wordCountEl = $('#word-count');
+  const charCountEl = $('#char-count');
+  const saveIndicatorEl = $('#save-indicator');
+  const versionSelectEl = $('#version-select');
+
+  const btnNew = $('#btn-new');
+  const btnImport = $('#btn-import');
+  const btnSaveHtml = $('#btn-save-html');
+  const btnExportMd = $('#btn-export-md');
+  const btnExportPdf = $('#btn-export-pdf');
+  const btnClear = $('#btn-clear');
+  const btnRestore = $('#btn-restore');
+  const btnUndo = $('#btn-undo');
+  const btnRedo = $('#btn-redo');
+  const themeToggle = $('#theme-toggle');
+
+  // Theme handling
+  function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    const meta = $('#meta-theme-color');
+    if (meta) meta.setAttribute('content', theme === 'dark' ? '#0b1320' : '#ffffff');
+  }
+  function initTheme() {
+    const saved = localStorage.getItem(STORAGE.theme);
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = saved || (prefersDark ? 'dark' : 'light');
+    applyTheme(theme);
+  }
+  function toggleTheme() {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    const next = current === 'light' ? 'dark' : 'light';
+    localStorage.setItem(STORAGE.theme, next);
+    applyTheme(next);
+  }
+
+  // Initialize Quill editor
+  let quill;
+  function initEditor() {
+    quill = new Quill('#editor', {
+      theme: 'snow',
+      modules: {
+        toolbar: '#toolbar',
+        history: { delay: 1000, maxStack: 500, userOnly: true }
+      }
+    });
+
+    // Undo/Redo buttons
+    btnUndo.addEventListener('click', () => quill.history.undo());
+    btnRedo.addEventListener('click', () => quill.history.redo());
+
+    // Update counts on change
+    quill.on('text-change', updateCounts);
+  }
+
+  // Word/char counts
+  function updateCounts() {
+    const text = quill.getText() || '';
+    const trimmed = text.trim();
+    const words = trimmed ? trimmed.split(/\s+/).length : 0;
+    const chars = trimmed.replace(/\s/g, '').length;
+    wordCountEl.textContent = words.toString();
+    charCountEl.textContent = chars.toString();
+  }
+
+  // Save indicator
+  function updateSaveIndicator() {
+    const dt = new Date();
+    const hh = String(dt.getHours()).padStart(2, '0');
+    const mm = String(dt.getMinutes()).padStart(2, '0');
+    const ss = String(dt.getSeconds()).padStart(2, '0');
+    saveIndicatorEl.textContent = `Saved ${hh}:${mm}:${ss}`;
+  }
+
+  // Snapshots (keep last 3)
+  function getSnapshots() {
+    try { return JSON.parse(localStorage.getItem(STORAGE.snapshots) || '[]'); } catch { return []; }
+  }
+  function setSnapshots(arr) {
+    localStorage.setItem(STORAGE.snapshots, JSON.stringify(arr.slice(0, 3)));
+  }
+  function addSnapshotFromDelta(deltaObj, title) {
+    if (!deltaObj) return;
+    const snapshots = getSnapshots();
+    snapshots.unshift({ ts: Date.now(), title: title || 'Untitled', delta: deltaObj });
+    setSnapshots(snapshots);
+    refreshVersionSelect();
+  }
+  function refreshVersionSelect() {
+    const snaps = getSnapshots();
+    versionSelectEl.innerHTML = '';
+    if (!snaps.length) {
+      const op = document.createElement('option');
+      op.textContent = '(none)';
+      versionSelectEl.appendChild(op);
+      return;
+    }
+    snaps.forEach((s, idx) => {
+      const op = document.createElement('option');
+      const when = new Date(s.ts).toLocaleString();
+      op.value = String(idx);
+      op.textContent = `${when} — ${s.title || 'Untitled'}`;
+      versionSelectEl.appendChild(op);
+    });
+  }
+
+  // Autosave
+  let lastDeltaJson = null;
+  function save(forceSnapshot = false) {
+    const title = (titleEl.value || '').trim() || 'Untitled Document';
+    const delta = quill.getContents();
+    const deltaJson = JSON.stringify(delta);
+
+    // Save snapshot of previous version when content changes
+    if ((lastDeltaJson && lastDeltaJson !== deltaJson) || forceSnapshot) {
+      try {
+        const prev = JSON.parse(lastDeltaJson || 'null');
+        if (prev) addSnapshotFromDelta(prev, localStorage.getItem(STORAGE.title) || title);
+      } catch { /* ignore */ }
+    }
+
+    localStorage.setItem(STORAGE.title, title);
+    localStorage.setItem(STORAGE.delta, deltaJson);
+    localStorage.setItem(STORAGE.html, quill.root.innerHTML);
+    lastDeltaJson = deltaJson;
+    updateSaveIndicator();
+  }
+
+  function restoreFromStorage() {
+    const savedTitle = localStorage.getItem(STORAGE.title) || '';
+    const savedDelta = localStorage.getItem(STORAGE.delta);
+    if (savedTitle) titleEl.value = savedTitle;
+    if (savedDelta) {
+      try { quill.setContents(JSON.parse(savedDelta)); } catch { /* ignore */ }
+    } else {
+      quill.setText('');
+    }
+    updateCounts();
+    refreshVersionSelect();
+  }
+
+  // Utilities
+  function downloadFile(filename, content, mime) {
+    const blob = new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = filename; a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+  function slugify(str) {
+    return (str || 'document').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 60) || 'document';
+  }
+
+  // Exporters
+  function exportHTML() {
+    const title = (titleEl.value || 'Document').trim() || 'Document';
+    const htmlContent = quill.root.innerHTML;
+    const full = `<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8"/>\n<meta name="viewport" content="width=device-width, initial-scale=1"/>\n<title>${title}</title>\n<style>\n  body{font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;background:#f6f7fb;color:#0f172a;margin:0;padding:2rem;}\n  .page{max-width:816px;margin:0 auto;background:#fff;border-radius:12px;box-shadow:0 10px 30px rgba(24,39,75,.12);border:1px solid #e2e8f0;}\n  .content{padding:2rem;min-height:400px;line-height:1.65;font-size:16px;}\n  .content h1{font-size:2em} .content h2{font-size:1.6em} .content h3{font-size:1.35em}\n  .ql-size-small{font-size:.75em} .ql-size-large{font-size:1.5em} .ql-size-huge{font-size:2.5em}\n  .ql-align-center{text-align:center}.ql-align-right{text-align:right}.ql-align-justify{text-align:justify}\n  blockquote{border-left:4px solid #e5e7eb;margin:1rem 0;padding:.5rem 1rem;color:#475569}\n  pre.ql-syntax{background:#0b1320;color:#e5e7eb;border-radius:8px;padding:1rem;overflow:auto}\n  img{max-width:100%;height:auto}\n</style>\n</head>\n<body>\n<article class="page">\n  <div class="content">${htmlContent}</div>\n</article>\n</body>\n</html>`;
+    downloadFile(`${slugify(title)}.html`, full, 'text/html');
+  }
+
+  function exportMarkdown() {
+    const title = (titleEl.value || 'Document').trim() || 'Document';
+    const td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
+    const html = quill.root.innerHTML;
+    const md = td.turndown(html);
+    downloadFile(`${slugify(title)}.md`, md, 'text/markdown');
+  }
+
+  function exportPDF() {
+    const title = (titleEl.value || 'Document').trim() || 'Document';
+    const element = document.querySelector('#page');
+    const opt = {
+      margin: [10, 10, 10, 10],
+      filename: `${slugify(title)}.pdf`,
+      image: { type: 'jpeg', quality: 0.98 },
+      html2canvas: { scale: 2, useCORS: true },
+      jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
+    };
+    html2pdf().set(opt).from(element).save();
+  }
+
+  // Importer
+  function handleImportFile(file) {
+    const name = (file && file.name) || '';
+    const isJSON = /\.json$/i.test(name);
+    const isHTML = /\.(html|htm)$/i.test(name);
+    if (!isJSON && !isHTML) {
+      alert('Please select an HTML or JSON file.');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        if (isJSON) {
+          const obj = JSON.parse(reader.result);
+          let delta = null;
+          if (obj && obj.ops) delta = obj; // raw Quill delta
+          else if (obj && obj.delta && obj.delta.ops) delta = obj.delta; // wrapped
+          if (!delta) throw new Error('Invalid JSON: expected Quill Delta');
+          quill.setContents(delta);
+          if (obj.title) titleEl.value = obj.title;
+        } else if (isHTML) {
+          const html = reader.result;
+          quill.clipboard.dangerouslyPasteHTML(html);
+        }
+        save(true);
+        updateCounts();
+        alert('Import complete.');
+      } catch (e) {
+        console.error(e);
+        alert('Failed to import file. Make sure the JSON is a Quill Delta or the HTML is valid.');
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  // Actions
+  function bindActions() {
+    themeToggle.addEventListener('click', toggleTheme);
+
+    btnNew.addEventListener('click', () => {
+      const hasContent = (quill.getText() || '').trim().length > 0 || (titleEl.value || '').trim().length > 0;
+      if (!hasContent || confirm('Start a new document? Unsaved changes will be kept in versions.')) {
+        titleEl.value = '';
+        quill.setText('');
+        save(true);
+        updateCounts();
+      }
+    });
+
+    btnImport.addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', (e) => {
+      const file = e.target.files && e.target.files[0];
+      if (file) handleImportFile(file);
+      fileInput.value = '';
+    });
+
+    btnSaveHtml.addEventListener('click', exportHTML);
+    btnExportMd.addEventListener('click', exportMarkdown);
+    btnExportPdf.addEventListener('click', exportPDF);
+
+    btnClear.addEventListener('click', () => {
+      if (!confirm('Clear all local data (title, content, snapshots)? This cannot be undone.')) return;
+      localStorage.removeItem(STORAGE.title);
+      localStorage.removeItem(STORAGE.delta);
+      localStorage.removeItem(STORAGE.html);
+      localStorage.removeItem(STORAGE.snapshots);
+      titleEl.value = '';
+      quill.setText('');
+      lastDeltaJson = null;
+      refreshVersionSelect();
+      updateCounts();
+      updateSaveIndicator();
+      alert('Local data cleared.');
+    });
+
+    btnRestore.addEventListener('click', () => {
+      const idx = parseInt(versionSelectEl.value, 10);
+      const snaps = getSnapshots();
+      if (Number.isNaN(idx) || !snaps[idx]) { alert('No snapshot selected.'); return; }
+      const snap = snaps[idx];
+      quill.setContents(snap.delta);
+      if (snap.title) titleEl.value = snap.title;
+      save(true);
+      updateCounts();
+    });
+  }
+
+  // Autosave timer & lifecycle
+  function bindAutosave() {
+    setInterval(() => save(false), 5000);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') save(false);
+    });
+    window.addEventListener('beforeunload', () => save(false));
+    titleEl.addEventListener('blur', () => save(false));
+  }
+
+  // Boot
+  document.addEventListener('DOMContentLoaded', () => {
+    initTheme();
+    initEditor();
+    bindActions();
+    bindAutosave();
+    restoreFromStorage();
+    updateSaveIndicator();
+  });
+})();

--- a/Django-Doc_app/editor/templates/editor/index.html
+++ b/Django-Doc_app/editor/templates/editor/index.html
@@ -1,0 +1,131 @@
+{% load static %}
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Simple Google Docs-like editor built with Django + Quill.js. Offline-capable with autosave and exports." />
+    <meta name="theme-color" content="#ffffff" id="meta-theme-color" />
+    <title>Simple Google Docs Clone</title>
+
+    <link rel="icon" href="{% static 'editor/favicon.svg' %}" />
+
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+
+    <!-- Quill CSS (Snow theme) -->
+    <link href="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css" rel="stylesheet">
+
+    <!-- Font Awesome Icons -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+
+    <!-- App styles -->
+    <link href="{% static 'editor/css/styles.css' %}" rel="stylesheet" />
+  </head>
+  <body>
+    <noscript>This app requires JavaScript to run.</noscript>
+
+    <!-- App bar -->
+    <header class="appbar">
+      <div class="appbar__left">
+        <i class="fa-solid fa-note-sticky appbar__logo" aria-hidden="true"></i>
+        <span class="appbar__brand">Docs Clone</span>
+      </div>
+      <div class="appbar__right">
+        <button id="theme-toggle" class="icon-btn" title="Toggle theme" aria-label="Toggle theme">
+          <i class="fa-solid fa-moon"></i>
+        </button>
+      </div>
+    </header>
+
+    <main class="container">
+      <!-- Title row -->
+      <section class="title-row">
+        <input id="doc-title" class="title-input" placeholder="Untitled document" aria-label="Document title" />
+        <div class="actions">
+          <button id="btn-new" class="btn"><i class="fa-solid fa-file-circle-plus"></i><span>New</span></button>
+          <button id="btn-import" class="btn"><i class="fa-solid fa-file-arrow-up"></i><span>Import</span></button>
+          <button id="btn-save-html" class="btn"><i class="fa-solid fa-floppy-disk"></i><span>Save HTML</span></button>
+          <button id="btn-export-md" class="btn"><i class="fa-brands fa-markdown"></i><span>Export MD</span></button>
+          <button id="btn-export-pdf" class="btn"><i class="fa-solid fa-file-pdf"></i><span>Export PDF</span></button>
+          <button id="btn-clear" class="btn btn-danger"><i class="fa-solid fa-trash"></i><span>Clear Data</span></button>
+
+          <label class="versions" title="Restore a previous autosave snapshot">
+            <i class="fa-solid fa-clock-rotate-left"></i>
+            <span>Versions</span>
+            <select id="version-select">
+              <option>(none)</option>
+            </select>
+            <button id="btn-restore" class="btn btn-secondary">Restore</button>
+          </label>
+
+          <input id="file-input" type="file" accept=".html,.htm,.json" hidden />
+        </div>
+      </section>
+
+      <!-- Toolbar (Quill) -->
+      <div id="toolbar" class="toolbar">
+        <span class="ql-formats">
+          <select class="ql-header">
+            <option selected></option>
+            <option value="1">H1</option>
+            <option value="2">H2</option>
+            <option value="3">H3</option>
+          </select>
+          <select class="ql-size">
+            <option value="small"></option>
+            <option selected></option>
+            <option value="large"></option>
+            <option value="huge"></option>
+          </select>
+        </span>
+        <span class="ql-formats">
+          <button class="ql-bold"></button>
+          <button class="ql-italic"></button>
+          <button class="ql-underline"></button>
+          <button class="ql-strike"></button>
+        </span>
+        <span class="ql-formats">
+          <select class="ql-color"></select>
+          <select class="ql-background"></select>
+        </span>
+        <span class="ql-formats">
+          <button class="ql-list" value="ordered"></button>
+          <button class="ql-list" value="bullet"></button>
+          <button class="ql-blockquote"></button>
+          <button class="ql-code-block"></button>
+        </span>
+        <span class="ql-formats">
+          <button class="ql-link"></button>
+          <button class="ql-image"></button>
+        </span>
+        <span class="ql-formats">
+          <button id="btn-undo" type="button" title="Undo"><i class="fa-solid fa-rotate-left"></i></button>
+          <button id="btn-redo" type="button" title="Redo"><i class="fa-solid fa-rotate-right"></i></button>
+          <button class="ql-clean"></button>
+        </span>
+      </div>
+
+      <!-- Page & Editor -->
+      <section id="page" class="page">
+        <div id="editor" class="editor"></div>
+      </section>
+
+      <!-- Status bar -->
+      <footer class="status-bar">
+        <div>
+          <span id="word-count">0</span> words · <span id="char-count">0</span> chars
+        </div>
+        <div id="save-indicator" class="save-indicator" aria-live="polite">&nbsp;</div>
+      </footer>
+    </main>
+
+    <!-- Scripts: Quill, Turndown, html2pdf, App -->
+    <script src="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/turndown@7.1.2/dist/turndown.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2pdf.js@0.10.1/dist/html2pdf.bundle.min.js"></script>
+    <script src="{% static 'editor/js/app.js' %}"></script>
+  </body>
+</html>

--- a/Django-Doc_app/editor/urls.py
+++ b/Django-Doc_app/editor/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("", views.index, name="editor-index"),
+]

--- a/Django-Doc_app/editor/views.py
+++ b/Django-Doc_app/editor/views.py
@@ -1,0 +1,9 @@
+from django.shortcuts import render
+
+
+def index(request):
+    """Render the main editor page.
+
+    This view serves a single-page rich text editor. All editing logic is client-side.
+    """
+    return render(request, "editor/index.html")

--- a/Django-Doc_app/manage.py
+++ b/Django-Doc_app/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""
+Django's command-line utility for administrative tasks.
+"""
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_google_doc_clone.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and available on your PYTHONPATH environment variable? Did you forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/Django-Doc_app/requirements.txt
+++ b/Django-Doc_app/requirements.txt
@@ -1,0 +1,2 @@
+Django==4.2
+gunicorn==21.2.0


### PR DESCRIPTION
This beginner-friendly Django project inspired by Google Docs.
The project includes a fully functional web-based text editor built using Django, Quill.js, and LocalStorage for autosave functionality.
It allows users to create, edit, format, and export rich text documents - all within the browser.

🚀 Key Features:
1. Rich-text editing (bold, italic, underline, lists, headings, etc.)
2. Autosave to browser storage
3. Export as HTML, Markdown, or PDF
4. Light/Dark mode toggle
5. Editable document title and live word count
6. Fully responsive and deployable web app

🛠 Tech Stack: Django, HTML, CSS, JavaScript, Quill.js, Turndown.js, html2pdf.js