### PR TITLE
feat(auth): Add Remember Me functionality to login page

### DIFF
--- a/User Authentication system/users/templates/users/login.html
+++ b/User Authentication system/users/templates/users/login.html
@@ -1,79 +1,114 @@
-{% extends "users/base.html" %}
-{% block title %} Login Page {% endblock title%}
+{% extends "users/base.html" %} {% block title %} Login Page {% endblock title%}
 {% block content %}
-    <div class="form-content my-3 p-3">
-        <div class="container">
-            <div class="row justify-content-center">
-                <div class="col-lg-5">
-                    <div class="card shadow-lg border-0 rounded-lg mt-0 mb-3">
-                        <div class="card-header justify-content-center">
-                          <h3 class="font-weight-light my-1 text-center">Sign In</h3>
-                        </div>
-                        {% if form.errors %}
-                            <div class="alert alert-danger alert-dismissible" role="alert">
-                                <div id="form_errors">
-                                    {% for key, value in form.errors.items %}
-                                        <strong>{{ value }}</strong>
-                                    {% endfor %}
-                                </div>
-                                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                                    <span aria-hidden="true">&times;</span>
-                                </button>
-                            </div>
-                        {% endif %}
-                        <div class="card-body">
-                            <form method="POST">
-                                {% csrf_token %}
-                                <div class="form-row">
-                                    <div class="col-md-10 offset-md-1">
-                                        <div class="form-group">
-                                            <a href="{% url 'social:begin' 'github' %}"
-                                                   class="btn btn-link btn-lg active btn-block">Sign in with GitHub</a>
-                                            <a href="{% url 'social:begin' 'google-oauth2' %}"
-                                                   class="btn btn-link btn-lg active btn-block">Sign in with Google</a>
-                                            <hr>
-                                            <p class="text-center"><strong>OR</strong></p>
-                                            <hr>
-                                            <label class="small mb-1">Username</label>
-                                            {{ form.username }}
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="form-row">
-                                    <div class="col-md-10 offset-md-1">
-                                        <div class="form-group">
-                                          <label class="small mb-1">Password</label>
-                                          {{ form.password }}
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="form-row">
-                                    <div class="col-md-10 offset-md-1">
-                                        <div class="form-group">
-                                            <!-- Add a Remember me functionality -->
-                                            {{ form.remember_me }}
-                                            <label> Remember me</label>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="form-row">
-                                    <div class="col-md-10 offset-md-1">
-                                        <div class="form-group mt-0 mb-1">
-                                          <button name="login" class="col-md-12 btn btn-dark" id="login">Sign in</button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </form>
-                        </div>
-                        <div class="card-footer text-center">
-                            <div class="small">
-                                <a href="{% url 'users-register' %}">Don't have an account yet? Go to signup</a><br>
-                                <a href="{% url 'password_reset' %}"><i>Forgot Password?</i></a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+<div class="form-content my-3 p-3">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-lg-5">
+        <div class="card shadow-lg border-0 rounded-lg mt-0 mb-3">
+          <div class="card-header justify-content-center">
+            <h3 class="font-weight-light my-1 text-center">Sign In</h3>
+          </div>
+          {% if form.errors %}
+          <div class="alert alert-danger alert-dismissible" role="alert">
+            <div id="form_errors">
+              {% for key, value in form.errors.items %}
+              <strong>{{ value }}</strong>
+              {% endfor %}
             </div>
+            <button
+              type="button"
+              class="close"
+              data-dismiss="alert"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          {% endif %}
+          <div class="card-body">
+            <form method="POST">
+              {% csrf_token %}
+              <div class="form-row">
+                <div class="col-md-10 offset-md-1">
+                  <div class="form-group">
+                    <a
+                      href="{% url 'social:begin' 'github' %}"
+                      class="btn btn-link btn-lg active btn-block"
+                      >Sign in with GitHub</a
+                    >
+                    <a
+                      href="{% url 'social:begin' 'google-oauth2' %}"
+                      class="btn btn-link btn-lg active btn-block"
+                      >Sign in with Google</a
+                    >
+                    <hr />
+                    <p class="text-center"><strong>OR</strong></p>
+                    <hr />
+                    <label class="small mb-1">Username</label>
+                    {{ form.username }}
+                  </div>
+                </div>
+              </div>
+              <div class="form-row">
+                <div class="col-md-10 offset-md-1">
+                  <div class="form-group">
+                    <label class="small mb-1">Password</label>
+                    {{ form.password }}
+                  </div>
+                </div>
+              </div>
+
+              <!-- ✅ Remember Me Feature Added -->
+              <!-- Checkbox checked হলে → 30 দিন session থাকবে -->
+              <!-- Checkbox unchecked হলে → browser বন্ধে session শেষ -->
+              <div class="form-row">
+                <div class="col-md-10 offset-md-1">
+                  <div class="form-group">
+                    <div class="form-check">
+                      <input
+                        class="form-check-input"
+                        type="checkbox"
+                        name="remember_me"
+                        id="remember_me"
+                      />
+                      <label class="form-check-label" for="remember_me">
+                        Remember me
+                        <small class="text-muted"
+                          >(Stay logged in for 30 days)</small
+                        >
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <!-- ✅ Remember Me Feature End -->
+
+              <div class="form-row">
+                <div class="col-md-10 offset-md-1">
+                  <div class="form-group mt-0 mb-1">
+                    <button
+                      name="login"
+                      class="col-md-12 btn btn-dark"
+                      id="login"
+                    >
+                      Sign in
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+          <div class="card-footer text-center">
+            <div class="small">
+              <a href="{% url 'users-register' %}"
+                >Don't have an account yet? Go to signup</a
+              ><br />
+              <a href="{% url 'password_reset' %}"><i>Forgot Password?</i></a>
+            </div>
+          </div>
         </div>
-     </div>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock content %}


### PR DESCRIPTION
## What does this PR do?
Adds a "Remember Me" checkbox to the login page that allows users to persist their session for 30 days.

## Changes Made
- `templates/users/login.html` → Added Remember Me checkbox UI

## How it works
- ✅ Checkbox checked → session lasts 30 days
- ❌ Checkbox unchecked → session ends when browser closes

## Related
- Logic already existed in `views.py` (CustomLoginView) and `forms.py` (LoginForm)
- This PR completes the UI part of the feature