### PR TITLE
Add duplicate username and email validation for staff creation

### DIFF
--- a/Django Intermediate Projects/Student management system/student_management_app/HodViews.py
+++ b/Django Intermediate Projects/Student management system/student_management_app/HodViews.py
@@ -104,6 +104,14 @@ def add_staff_save(request):
         password = request.POST.get('password')
         address = request.POST.get('address')
 
+        if CustomUser.objects.filter(username=username).exists():
+            messages.error(request, "Username already exists!")
+            return redirect('add_staff')
+
+        if CustomUser.objects.filter(email=email).exists():
+            messages.error(request, "Email already exists!")
+            return redirect('add_staff')
+
         try:
             user = CustomUser.objects.create_user(username=username, password=password, email=email, first_name=first_name, last_name=last_name, user_type=2)
             user.staffs.address = address


### PR DESCRIPTION
## Issue

Duplicate usernames and emails could be created during staff creation, which may lead to authentication inconsistencies and duplicate staff accounts.

## Changes Made

* Added validation checks for existing usernames during staff creation
* Added validation checks for existing emails during staff creation
* Displayed user-friendly error messages for duplicate entries

## Result

The system now prevents duplicate usernames and emails when adding new staff members.
