### PR TITLE
Fix dynamic student form choices

### DIFF
--- a/Django Intermediate Projects/Student management system/student_management_app/HodViews.py
+++ b/Django Intermediate Projects/Student management system/student_management_app/HodViews.py
@@ -366,7 +366,14 @@ def add_student_save(request):
                 profile_pic_url = fs.url(filename)
             else:
                 profile_pic_url = None
+            
+            if CustomUser.objects.filter(username=username).exists():
+                messages.error(request, "Username already exists!")
+                return redirect('add_staff')
 
+            if CustomUser.objects.filter(email=email).exists():
+                messages.error(request, "Email already exists!")
+                return redirect('add_staff')
 
             try:
                 user = CustomUser.objects.create_user(username=username, password=password, email=email, first_name=first_name, last_name=last_name, user_type=3)

--- a/Django Intermediate Projects/Student management system/student_management_app/forms.py
+++ b/Django Intermediate Projects/Student management system/student_management_app/forms.py
@@ -15,40 +15,50 @@ class AddStudentForm(forms.Form):
     username = forms.CharField(label="Username", max_length=50, widget=forms.TextInput(attrs={"class":"form-control"}))
     address = forms.CharField(label="Address", max_length=50, widget=forms.TextInput(attrs={"class":"form-control"}))
 
-    #For Displaying Courses
-    try:
-        courses = Courses.objects.all()
-        course_list = []
-        for course in courses:
-            single_course = (course.id, course.course_name)
-            course_list.append(single_course)
-    except:
-        course_list = []
-    
-    #For Displaying Session Years
-    try:
-        session_years = SessionYearModel.objects.all()
-        session_year_list = []
-        for session_year in session_years:
-            single_session_year = (session_year.id, str(session_year.session_start_year)+" to "+str(session_year.session_end_year))
-            session_year_list.append(single_session_year)
-            
-    except:
-        session_year_list = []
-    
     gender_list = (
         ('Male','Male'),
         ('Female','Female')
     )
-    
-    course_id = forms.ChoiceField(label="Course", choices=course_list, widget=forms.Select(attrs={"class":"form-control"}))
-    gender = forms.ChoiceField(label="Gender", choices=gender_list, widget=forms.Select(attrs={"class":"form-control"}))
-    session_year_id = forms.ChoiceField(label="Session Year", choices=session_year_list, widget=forms.Select(attrs={"class":"form-control"}))
-    # session_start_year = forms.DateField(label="Session Start", widget=DateInput(attrs={"class":"form-control"}))
-    # session_end_year = forms.DateField(label="Session End", widget=DateInput(attrs={"class":"form-control"}))
-    profile_pic = forms.FileField(label="Profile Pic", required=False, widget=forms.FileInput(attrs={"class":"form-control"}))
 
+    course_id = forms.ChoiceField(
+        label="Course",
+        choices=[],
+        widget=forms.Select(attrs={"class":"form-control"})
+    )
 
+    gender = forms.ChoiceField(
+        label="Gender",
+        choices=gender_list,
+        widget=forms.Select(attrs={"class":"form-control"})
+    )
+
+    session_year_id = forms.ChoiceField(
+        label="Session Year",
+        choices=[],
+        widget=forms.Select(attrs={"class":"form-control"})
+    )
+
+    profile_pic = forms.FileField(
+        label="Profile Pic",
+        required=False,
+        widget=forms.FileInput(attrs={"class":"form-control"})
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['course_id'].choices = [
+            (course.id, course.course_name)
+            for course in Courses.objects.all()
+        ]
+
+        self.fields['session_year_id'].choices = [
+            (
+                session.id,
+                f"{session.session_start_year} to {session.session_end_year}"
+            )
+            for session in SessionYearModel.objects.all()
+        ]
 
 class EditStudentForm(forms.Form):
     email = forms.EmailField(label="Email", max_length=50, widget=forms.EmailInput(attrs={"class":"form-control"}))
@@ -57,36 +67,47 @@ class EditStudentForm(forms.Form):
     username = forms.CharField(label="Username", max_length=50, widget=forms.TextInput(attrs={"class":"form-control"}))
     address = forms.CharField(label="Address", max_length=50, widget=forms.TextInput(attrs={"class":"form-control"}))
 
-    #For Displaying Courses
-    try:
-        courses = Courses.objects.all()
-        course_list = []
-        for course in courses:
-            single_course = (course.id, course.course_name)
-            course_list.append(single_course)
-    except:
-        course_list = []
-
-    #For Displaying Session Years
-    try:
-        session_years = SessionYearModel.objects.all()
-        session_year_list = []
-        for session_year in session_years:
-            single_session_year = (session_year.id, str(session_year.session_start_year)+" to "+str(session_year.session_end_year))
-            session_year_list.append(single_session_year)
-            
-    except:
-        session_year_list = []
-
-    
     gender_list = (
         ('Male','Male'),
         ('Female','Female')
     )
-    
-    course_id = forms.ChoiceField(label="Course", choices=course_list, widget=forms.Select(attrs={"class":"form-control"}))
-    gender = forms.ChoiceField(label="Gender", choices=gender_list, widget=forms.Select(attrs={"class":"form-control"}))
-    session_year_id = forms.ChoiceField(label="Session Year", choices=session_year_list, widget=forms.Select(attrs={"class":"form-control"}))
-    # session_start_year = forms.DateField(label="Session Start", widget=DateInput(attrs={"class":"form-control"}))
-    # session_end_year = forms.DateField(label="Session End", widget=DateInput(attrs={"class":"form-control"}))
-    profile_pic = forms.FileField(label="Profile Pic", required=False, widget=forms.FileInput(attrs={"class":"form-control"}))
+
+    course_id = forms.ChoiceField(
+        label="Course",
+        choices=[],
+        widget=forms.Select(attrs={"class":"form-control"})
+    )
+
+    gender = forms.ChoiceField(
+        label="Gender",
+        choices=gender_list,
+        widget=forms.Select(attrs={"class":"form-control"})
+    )
+
+    session_year_id = forms.ChoiceField(
+        label="Session Year",
+        choices=[],
+        widget=forms.Select(attrs={"class":"form-control"})
+    )
+
+    profile_pic = forms.FileField(
+        label="Profile Pic",
+        required=False,
+        widget=forms.FileInput(attrs={"class":"form-control"})
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['course_id'].choices = [
+            (course.id, course.course_name)
+            for course in Courses.objects.all()
+        ]
+
+        self.fields['session_year_id'].choices = [
+            (
+                session.id,
+                f"{session.session_start_year} to {session.session_end_year}"
+            )
+            for session in SessionYearModel.objects.all()
+        ]


### PR DESCRIPTION
## Issue

Course and session dropdowns in the Add Student and Edit Student forms were populated when the form module was imported. As a result, newly added courses and session years were not reflected in the dropdowns until the Django server was restarted.

## Changes Made

* Moved course choice population from class definition time to the form `__init__()` method.
* Moved session year choice population from class definition time to the form `__init__()` method.
* Applied the fix to both `AddStudentForm` and `EditStudentForm`.

## Result

Course and session dropdowns now fetch the latest data whenever the form is loaded, eliminating the need to restart the server after adding new courses or session years.
